### PR TITLE
Add dedication and epigraph

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -124,6 +124,9 @@
 		<item href="text/chapter-24.xhtml" id="chapter-24.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/chapter-25.xhtml" id="chapter-25.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/colophon.xhtml" id="colophon.xhtml" media-type="application/xhtml+xml" properties="svg"/>
+		<item href="text/dedication.xhtml" id="dedication.xhtml" media-type="application/xhtml+xml"/>
+		<item href="text/epigraph.xhtml" id="epigraph.xhtml" media-type="application/xhtml+xml"/>
+		<item href="text/halftitlepage.xhtml" id="halftitlepage.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/imprint.xhtml" id="imprint.xhtml" media-type="application/xhtml+xml" properties="svg"/>
 		<item href="text/titlepage.xhtml" id="titlepage.xhtml" media-type="application/xhtml+xml" properties="svg"/>
 		<item href="text/uncopyright.xhtml" id="uncopyright.xhtml" media-type="application/xhtml+xml"/>
@@ -132,6 +135,9 @@
 	<spine>
 		<itemref idref="titlepage.xhtml"/>
 		<itemref idref="imprint.xhtml"/>
+		<itemref idref="dedication.xhtml"/>
+		<itemref idref="epigraph.xhtml"/>
+		<itemref idref="halftitlepage.xhtml"/>
 		<itemref idref="chapter-1.xhtml"/>
 		<itemref idref="chapter-2.xhtml"/>
 		<itemref idref="chapter-3.xhtml"/>

--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -56,8 +56,8 @@
 		<dc:language>en-US</dc:language>
 		<dc:source>https://www.pgdp.net/c/project.php?id=projectID624808f2a8907</dc:source>
 		<dc:source>https://catalog.hathitrust.org/Record/000536779</dc:source>
-		<meta property="se:word-count">47127</meta>
-		<meta property="se:reading-ease.flesch">65.22</meta>
+		<meta property="se:word-count">47159</meta>
+		<meta property="se:reading-ease.flesch">65.32</meta>
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Quicksand_(Larsen_novel)</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/nella-larsen_quicksand</meta>
 		<dc:creator id="author">Nella Larsen</dc:creator>

--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -1,6 +1,36 @@
 @charset "utf-8";
 @namespace epub "http://www.idpf.org/2007/ops";
 
+/* Centered dedications */
+section[epub|type~="dedication"]{
+	text-align: center;
+	font-variant: small-caps;
+}
+
+section[epub|type~="dedication"] > *{
+	display: inline-block;
+	margin: auto;
+	margin-top: 3em;
+	max-width: 80%;
+}
+
+@supports(display: flex){
+	section[epub|type~="dedication"]{
+		align-items: center;
+		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		min-height: calc(98vh - 3em);
+		padding-top: 3em;
+	}
+
+	section[epub|type~="dedication"] > *{
+		margin: 0;
+	}
+}
+/* End centered dedications */
+
 /* Begin letter css */
 [epub|type~="z3998:letter"] header{
 	text-align: right;

--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -31,6 +31,50 @@ section[epub|type~="dedication"] > *{
 }
 /* End centered dedications */
 
+/* All epigraphs */
+[epub|type~="epigraph"]{
+	font-style: italic;
+	hyphens: none;
+	-epub-hyphens: none;
+}
+
+[epub|type~="epigraph"] cite{
+	font-style: normal;
+	font-variant: small-caps;
+	margin-top: 1em;
+}
+/* End all epigraphs */
+
+/* Full-page epigraphs */
+section[epub|type~="epigraph"]{
+	text-align: center;
+}
+
+section[epub|type~="epigraph"] > *{
+	display: inline-block;
+	margin: auto;
+	margin-top: 3em;
+	max-width: 80%;
+	text-align: initial;
+}
+
+@supports(display: flex){
+	section[epub|type~="epigraph"]{
+		align-items: center;
+		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		min-height: calc(98vh - 3em);
+		padding-top: 3em;
+	}
+
+	section[epub|type~="epigraph"] > *{
+		margin: 0;
+	}
+}
+/* End full-page epigraphs */
+
 /* Begin letter css */
 [epub|type~="z3998:letter"] header{
 	text-align: right;

--- a/src/epub/text/dedication.xhtml
+++ b/src/epub/text/dedication.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>Dedication</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="dedication" epub:type="dedication">
+			<p>For <abbr epub:type="z3998:personal-name">E. S. I.</abbr></p>
+		</section>
+	</body>
+</html>

--- a/src/epub/text/epigraph.xhtml
+++ b/src/epub/text/epigraph.xhtml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>Epigraph</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="epigraph" epub:type="epigraph z3998:poem">
+			<blockquote>
+				<p>
+					<span>My old man died in a fine big house.</span>
+					<br/>
+					<span>My ma died in a shack.</span>
+					<br/>
+					<span>I wonder where I'm gonna die,</span>
+					<br/>
+					<span>Being neither white nor black?</span>
+				</p>
+				<cite>Langston Hughes</cite>
+			</blockquote>
+		</section>
+	</body>
+</html>

--- a/src/epub/text/halftitlepage.xhtml
+++ b/src/epub/text/halftitlepage.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>Quicksand</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="halftitlepage" epub:type="halftitlepage">
+			<h2 epub:type="fulltitle">Quicksand</h2>
+		</section>
+	</body>
+</html>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -14,79 +14,90 @@
 					<a href="text/imprint.xhtml">Imprint</a>
 				</li>
 				<li>
-					<a href="text/chapter-1.xhtml" epub:type="z3998:roman">I</a>
+					<a href="text/dedication.xhtml">Dedication</a>
 				</li>
 				<li>
-					<a href="text/chapter-2.xhtml" epub:type="z3998:roman">II</a>
+					<a href="text/epigraph.xhtml">Epigraph</a>
 				</li>
 				<li>
-					<a href="text/chapter-3.xhtml" epub:type="z3998:roman">III</a>
-				</li>
-				<li>
-					<a href="text/chapter-4.xhtml" epub:type="z3998:roman">IV</a>
-				</li>
-				<li>
-					<a href="text/chapter-5.xhtml" epub:type="z3998:roman">V</a>
-				</li>
-				<li>
-					<a href="text/chapter-6.xhtml" epub:type="z3998:roman">VI</a>
-				</li>
-				<li>
-					<a href="text/chapter-7.xhtml" epub:type="z3998:roman">VII</a>
-				</li>
-				<li>
-					<a href="text/chapter-8.xhtml" epub:type="z3998:roman">VIII</a>
-				</li>
-				<li>
-					<a href="text/chapter-9.xhtml" epub:type="z3998:roman">IX</a>
-				</li>
-				<li>
-					<a href="text/chapter-10.xhtml" epub:type="z3998:roman">X</a>
-				</li>
-				<li>
-					<a href="text/chapter-11.xhtml" epub:type="z3998:roman">XI</a>
-				</li>
-				<li>
-					<a href="text/chapter-12.xhtml" epub:type="z3998:roman">XII</a>
-				</li>
-				<li>
-					<a href="text/chapter-13.xhtml" epub:type="z3998:roman">XIII</a>
-				</li>
-				<li>
-					<a href="text/chapter-14.xhtml" epub:type="z3998:roman">XIV</a>
-				</li>
-				<li>
-					<a href="text/chapter-15.xhtml" epub:type="z3998:roman">XV</a>
-				</li>
-				<li>
-					<a href="text/chapter-16.xhtml" epub:type="z3998:roman">XVI</a>
-				</li>
-				<li>
-					<a href="text/chapter-17.xhtml" epub:type="z3998:roman">XVII</a>
-				</li>
-				<li>
-					<a href="text/chapter-18.xhtml" epub:type="z3998:roman">XVIII</a>
-				</li>
-				<li>
-					<a href="text/chapter-19.xhtml" epub:type="z3998:roman">XIX</a>
-				</li>
-				<li>
-					<a href="text/chapter-20.xhtml" epub:type="z3998:roman">XX</a>
-				</li>
-				<li>
-					<a href="text/chapter-21.xhtml" epub:type="z3998:roman">XXI</a>
-				</li>
-				<li>
-					<a href="text/chapter-22.xhtml" epub:type="z3998:roman">XXII</a>
-				</li>
-				<li>
-					<a href="text/chapter-23.xhtml" epub:type="z3998:roman">XXIII</a>
-				</li>
-				<li>
-					<a href="text/chapter-24.xhtml" epub:type="z3998:roman">XXIV</a>
-				</li>
-				<li>
-					<a href="text/chapter-25.xhtml" epub:type="z3998:roman">XXV</a>
+					<a href="text/halftitlepage.xhtml">Quicksand</a>
+					<ol>
+						<li>
+							<a href="text/chapter-1.xhtml" epub:type="z3998:roman">I</a>
+						</li>
+						<li>
+							<a href="text/chapter-2.xhtml" epub:type="z3998:roman">II</a>
+						</li>
+						<li>
+							<a href="text/chapter-3.xhtml" epub:type="z3998:roman">III</a>
+						</li>
+						<li>
+							<a href="text/chapter-4.xhtml" epub:type="z3998:roman">IV</a>
+						</li>
+						<li>
+							<a href="text/chapter-5.xhtml" epub:type="z3998:roman">V</a>
+						</li>
+						<li>
+							<a href="text/chapter-6.xhtml" epub:type="z3998:roman">VI</a>
+						</li>
+						<li>
+							<a href="text/chapter-7.xhtml" epub:type="z3998:roman">VII</a>
+						</li>
+						<li>
+							<a href="text/chapter-8.xhtml" epub:type="z3998:roman">VIII</a>
+						</li>
+						<li>
+							<a href="text/chapter-9.xhtml" epub:type="z3998:roman">IX</a>
+						</li>
+						<li>
+							<a href="text/chapter-10.xhtml" epub:type="z3998:roman">X</a>
+						</li>
+						<li>
+							<a href="text/chapter-11.xhtml" epub:type="z3998:roman">XI</a>
+						</li>
+						<li>
+							<a href="text/chapter-12.xhtml" epub:type="z3998:roman">XII</a>
+						</li>
+						<li>
+							<a href="text/chapter-13.xhtml" epub:type="z3998:roman">XIII</a>
+						</li>
+						<li>
+							<a href="text/chapter-14.xhtml" epub:type="z3998:roman">XIV</a>
+						</li>
+						<li>
+							<a href="text/chapter-15.xhtml" epub:type="z3998:roman">XV</a>
+						</li>
+						<li>
+							<a href="text/chapter-16.xhtml" epub:type="z3998:roman">XVI</a>
+						</li>
+						<li>
+							<a href="text/chapter-17.xhtml" epub:type="z3998:roman">XVII</a>
+						</li>
+						<li>
+							<a href="text/chapter-18.xhtml" epub:type="z3998:roman">XVIII</a>
+						</li>
+						<li>
+							<a href="text/chapter-19.xhtml" epub:type="z3998:roman">XIX</a>
+						</li>
+						<li>
+							<a href="text/chapter-20.xhtml" epub:type="z3998:roman">XX</a>
+						</li>
+						<li>
+							<a href="text/chapter-21.xhtml" epub:type="z3998:roman">XXI</a>
+						</li>
+						<li>
+							<a href="text/chapter-22.xhtml" epub:type="z3998:roman">XXII</a>
+						</li>
+						<li>
+							<a href="text/chapter-23.xhtml" epub:type="z3998:roman">XXIII</a>
+						</li>
+						<li>
+							<a href="text/chapter-24.xhtml" epub:type="z3998:roman">XXIV</a>
+						</li>
+						<li>
+							<a href="text/chapter-25.xhtml" epub:type="z3998:roman">XXV</a>
+						</li>
+					</ol>
 				</li>
 				<li>
 					<a href="text/colophon.xhtml">Colophon</a>


### PR DESCRIPTION
When starting this from the raw transcription at PGDP, I had removed all the front matter and forgot to add it back after splitting all the chapters. This restores the dedication and epigraph ([scans for reference](https://babel.hathitrust.org/cgi/pt?id=mdp.39015054061430&seq=9)).